### PR TITLE
* fix preview keeping cam busy (e.g. in liveview)

### DIFF
--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -216,10 +216,11 @@ int CameraController::preview(const char **file_data){
         this->_is_busy = false;
         return ret;
     }
-
+    this->_is_busy = false;
     *file_data = new char[file_size];
     memcpy((void *)*file_data, data, file_size);
     gp_file_unref(file);
+    
     return static_cast<int>(file_size);
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -192,6 +192,7 @@ int Server::url_handler (void *cls,
         MHD_add_response_header(response, "Content-Type", "multipart/x-mixed-replace;boundary=CCA_LV_FRAME");
     } else if(urlString.find("preview") != std::string::npos) {
         const char *data;
+        
         int size = s.cc->preview(&data);
         response = MHD_create_response_from_buffer(size, (void *)data, MHD_RESPMEM_MUST_COPY);
     	  MHD_add_response_header(response, "Content-Type", "image/jpeg");  
@@ -255,7 +256,6 @@ ssize_t Server::handle_mjpeg(void *cls, uint64_t pos, char *buf, size_t max){
 
     if(available < max) {
         const char *data;
-        s->cc->set_settings_value("autofocusdrive", "1");
         int size = s->cc->preview(&data);
         if(size < GP_OK)
             return MHD_CONTENT_READER_END_OF_STREAM;


### PR DESCRIPTION
* fix preview keeping cam busy (e.g. in liveview) 
*  add /preview to get one frame preview!


as mentioned in https://github.com/scheckmedia/CameraControllerApi/issues/8, i had troubles on getting a liveview + capture - so i tried to fix the _is_busy - bug.


then i realized that after a really long liveview (10GB+) chrome crashes.
this pr adds `/preview` - to send one single JPG back - and with javascript you can do a `.setIntervall()` to reload the pic, it is not perfect, but for our booth hardware stability wins over real mjpeg :)


